### PR TITLE
Another round of trying to get IPv6 to work.

### DIFF
--- a/__tests__/services/Libs.spec.ts
+++ b/__tests__/services/Libs.spec.ts
@@ -797,7 +797,7 @@ describe('Library Functions', () => {
         },
         {
           ...defaultExpression,
-          expression: 'fd12:3456:789a:1::1',
+          expression: '[fd12:3456:789a:1::1]',
         },
         {
           ...defaultExpression,
@@ -805,7 +805,7 @@ describe('Library Functions', () => {
         },
         {
           ...defaultExpression,
-          expression: 'fd12:3456:7890:1::/64',
+          expression: '[fd12:3456:7890:1::]/64',
         },
         {
           ...defaultExpression,
@@ -839,7 +839,7 @@ describe('Library Functions', () => {
     });
     it('should return expressions with matching IPv6 Address', () => {
       expect(
-        getMatchedExpressions(lists, 'default', 'fd12:3456:789a:1::1'),
+        getMatchedExpressions(lists, 'default', '[fd12:3456:789a:1::1]'),
       ).toEqual([lists['default'][2]]);
     });
     it('should return expressions with matching IPv4 Address with CIDR', () => {
@@ -849,7 +849,7 @@ describe('Library Functions', () => {
     });
     it('should return expressions with matching IPv6 Address with CIDR', () => {
       expect(
-        getMatchedExpressions(lists, 'default', 'fd12:3456:7890:1:5555::'),
+        getMatchedExpressions(lists, 'default', '[fd12:3456:7890:1:5555::]'),
       ).toEqual([lists['default'][4]]);
     });
     it('should return partial matched expressions when searching', () => {
@@ -1338,12 +1338,12 @@ describe('Library Functions', () => {
       ]);
     });
     it('should return proper IPv6 address', () => {
-      expect(prepareCleanupDomains('::1', browserName.Firefox)).toEqual([
+      expect(prepareCleanupDomains('[::1]', browserName.Firefox)).toEqual([
         '[::1]',
       ]);
     });
     it('should return proper IPv6 address for Chrome', () => {
-      expect(prepareCleanupDomains('::1', browserName.Chrome)).toEqual([
+      expect(prepareCleanupDomains('[::1]', browserName.Chrome)).toEqual([
         'http://[::1]',
         'https://[::1]',
       ]);
@@ -1377,7 +1377,7 @@ describe('Library Functions', () => {
       expect(
         prepareCookieDomain({
           ...mockCookie,
-          domain: '2001:0db8:85a3:0000:0000:8a2e:0370:7334',
+          domain: '[2001:0db8:85a3:0000:0000:8a2e:0370:7334]',
           path: '/',
           secure: true,
         }),

--- a/src/background.ts
+++ b/src/background.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017-2022 Kenny Do and CAD Team (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/graphs/contributors)
+ * Copyright (c) 2017-2023 Kenny Do and CAD Team (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/graphs/contributors)
  * Licensed under MIT (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/blob/3.X.X-Branch/LICENSE)
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR

--- a/src/redux/Reducers.ts
+++ b/src/redux/Reducers.ts
@@ -32,7 +32,7 @@ const newExpressionObject = (
   cleanSiteData: !action.payload.cleanSiteData
     ? []
     : action.payload.cleanSiteData,
-  id: shortid.generate(),
+  id: action.payload.id || shortid.generate(),
   listType: !action.payload.listType ? ListType.WHITE : action.payload.listType,
 });
 

--- a/src/ui/common_components/ExpressionOptions.tsx
+++ b/src/ui/common_components/ExpressionOptions.tsx
@@ -17,6 +17,7 @@ import { connect } from 'react-redux';
 import { Dispatch } from 'redux';
 import { updateExpressionUI } from '../../redux/Actions';
 import {
+  ipv6Prep,
   isChrome,
   isFirefox,
   isFirefoxNotAndroid,
@@ -116,7 +117,7 @@ class ExpressionOptions extends React.Component<ExpressionOptionsProps> {
       let allCookies;
       try {
         // Check if expression was a CIDR Notation
-        cidrEXP = ipaddr.parseCIDR(exp);
+        cidrEXP = ipaddr.parseCIDR(ipv6Prep(exp) || exp);
         allCookies = await browser.cookies.getAll(
           returnOptionalCookieAPIAttributes(this.props.state, {
             storeId: this.toPublicStoreId(expression.storeId),
@@ -136,7 +137,9 @@ class ExpressionOptions extends React.Component<ExpressionOptionsProps> {
           try {
             // eslint-disable-next-line @typescript-eslint/ban-ts-comment
             // @ts-ignore Union types of IPv4 and IPv6 not compatible.
-            return ipaddr.parse(cookie.domain).match(cidrEXP);
+            return ipaddr
+              .parse(ipv6Prep(cookie.domain) || cookie.domain)
+              .match(cidrEXP);
           } catch {
             // Cookie domain is not an IP Address
             return false;
@@ -172,8 +175,8 @@ class ExpressionOptions extends React.Component<ExpressionOptionsProps> {
                 ...expression,
                 cookieNames: checked
                   ? originalCookieNames.filter(
-                    (cookieName) => cookieName !== name,
-                  )
+                      (cookieName) => cookieName !== name,
+                    )
                   : [...originalCookieNames, name],
               });
             }}
@@ -279,28 +282,23 @@ class ExpressionOptions extends React.Component<ExpressionOptionsProps> {
     return (
       <div>
         {!expression.expression.startsWith('file:') &&
-          ((isFirefoxNotAndroid(state.cache) &&
-            ffVersion >= 78) ||
+          ((isFirefoxNotAndroid(state.cache) && ffVersion >= 78) ||
             isChrome(state.cache)) &&
           this.createSiteDataCheckbox(SiteDataType.CACHE)}
         {!expression.expression.startsWith('file:') &&
-          ((isFirefoxNotAndroid(state.cache) &&
-            ffVersion >= 77) ||
+          ((isFirefoxNotAndroid(state.cache) && ffVersion >= 77) ||
             isChrome(state.cache)) &&
           this.createSiteDataCheckbox(SiteDataType.INDEXEDDB)}
         {!expression.expression.startsWith('file:') &&
-          ((isFirefoxNotAndroid(state.cache) &&
-            ffVersion >= 58) ||
+          ((isFirefoxNotAndroid(state.cache) && ffVersion >= 58) ||
             isChrome(state.cache)) &&
           this.createSiteDataCheckbox(SiteDataType.LOCALSTORAGE)}
         {!expression.expression.startsWith('file:') &&
-          ((isFirefoxNotAndroid(state.cache) &&
-            ffVersion >= 78) ||
+          ((isFirefoxNotAndroid(state.cache) && ffVersion >= 78) ||
             isChrome(state.cache)) &&
           this.createSiteDataCheckbox(SiteDataType.PLUGINDATA)}
         {!expression.expression.startsWith('file:') &&
-          ((isFirefoxNotAndroid(state.cache) &&
-            ffVersion >= 77) ||
+          ((isFirefoxNotAndroid(state.cache) && ffVersion >= 77) ||
             isChrome(state.cache)) &&
           this.createSiteDataCheckbox(SiteDataType.SERVICEWORKERS)}
         <div className={'checkbox'}>
@@ -322,7 +320,7 @@ class ExpressionOptions extends React.Component<ExpressionOptionsProps> {
               icon={[
                 'far',
                 expression.cleanAllCookies === undefined ||
-                  expression.cleanAllCookies
+                expression.cleanAllCookies
                   ? 'check-square'
                   : 'square',
               ]}
@@ -337,7 +335,8 @@ class ExpressionOptions extends React.Component<ExpressionOptionsProps> {
               aria-labelledby={keyCleanAllCookies}
             >
               {browser.i18n.getMessage(
-                `keepAllCookies${expression.listType === ListType.GREY ? 'Grey' : ''
+                `keepAllCookies${
+                  expression.listType === ListType.GREY ? 'Grey' : ''
                 }Text`,
               )}
             </label>

--- a/src/ui/settings/ReleaseNotes.json
+++ b/src/ui/settings/ReleaseNotes.json
@@ -1,6 +1,12 @@
 {
   "releases": [
     {
+      "version": "3.9.0",
+      "notes": [
+        "Fixed:  More bugfix relating to IPv6 usage in extension.  Previous version only partially-fixed it."
+      ]
+    },
+    {
       "version": "3.8.2",
       "notes": [
         "Fixed:  Passing IP Addresses to browsingData / site data cleanups. Fixes #983 via PR#1451, with thanks to Rob W.",


### PR DESCRIPTION
Only remove IPv6 square brackets when putting it through the ipaddr parser.  

Also on expression updates, keep existing expression id.

Fixes #983 (again, hopefully).