### PR TITLE
Let Firefox on Android manage all storage types.

### DIFF
--- a/__tests__/services/Libs.spec.ts
+++ b/__tests__/services/Libs.spec.ts
@@ -43,6 +43,7 @@ import {
   returnOptionalCookieAPIAttributes,
   showNotification,
   sleep,
+  supportedStorageTypes,
   throwErrorNotification,
   trimDot,
   undefinedIsTrue,
@@ -1205,6 +1206,110 @@ describe('Library Functions', () => {
           platformOs: 'android',
         }),
       ).toBe(false);
+    });
+  });
+
+  describe('supportedStorageTypes', () => {
+    it('should return all false for undefined browser', () => {
+      expect(supportedStorageTypes(
+        { browserDetect: browserName.Unknown })
+      ).toStrictEqual({
+        cache: false,
+        indexedDb: false,
+        localStorage: false,
+        pluginData: false,
+        serviceWorkers: false,
+      });
+    });
+    it('should return all true for Chrome', () => {
+      expect(supportedStorageTypes(
+        { browserDetect: browserName.Chrome })
+      ).toStrictEqual({
+        cache: true,
+        indexedDb: true,
+        localStorage: true,
+        pluginData: true,
+        serviceWorkers: true,
+      });
+    });
+    it('should return all true for modern desktop Firefox', () => {
+      expect(supportedStorageTypes({
+        browserDetect: browserName.Firefox,
+        platformOs: 'linux',
+        browserVersion: '78.0.1'
+      })).toStrictEqual({
+        cache: true,
+        indexedDb: true,
+        localStorage: true,
+        pluginData: true,
+        serviceWorkers: true,
+      });
+    });
+    it('should return all true for old desktop Firefox', () => {
+      expect(supportedStorageTypes({
+        browserDetect: browserName.Firefox,
+        platformOs: 'linux',
+        browserVersion: '57.0.2'
+      })).toStrictEqual({
+        cache: false,
+        indexedDb: false,
+        localStorage: false,
+        pluginData: false,
+        serviceWorkers: false,
+      });
+    });
+    it('should only support local storage in FF 58 desktop', () => {
+      expect(supportedStorageTypes({
+        browserDetect: browserName.Firefox,
+        platformOs: 'linux',
+        browserVersion: '58.0.0'
+      })).toStrictEqual({
+        cache: false,
+        indexedDb: false,
+        localStorage: true,
+        pluginData: false,
+        serviceWorkers: false,
+      });
+    });
+    it('should support all but cache and plugin data in FF 77 desktop', () => {
+      expect(supportedStorageTypes({
+        browserDetect: browserName.Firefox,
+        platformOs: 'linux',
+        browserVersion: '77.0.0'
+      })).toStrictEqual({
+        cache: false,
+        indexedDb: true,
+        localStorage: true,
+        pluginData: false,
+        serviceWorkers: true,
+      });
+    });
+    it('should return all true for modern android Firefox', () => {
+      expect(supportedStorageTypes({
+        browserDetect: browserName.Firefox,
+        platformOs: 'android',
+        browserVersion: '85.0.0'
+      })).toStrictEqual({
+        cache: true,
+        indexedDb: true,
+        localStorage: true,
+        pluginData: true,
+        serviceWorkers: true,
+      });
+    });
+    it('should return all false for old android Firefox', () => {
+      expect(supportedStorageTypes({
+        browserDetect: browserName.Firefox,
+        platformOs: 'android',
+        // Notably produces different results for FF desktop above.
+        browserVersion: '77.0.0'
+      })).toStrictEqual({
+        cache: false,
+        indexedDb: false,
+        localStorage: false,
+        pluginData: false,
+        serviceWorkers: false,
+      });
     });
   });
 

--- a/src/redux/Actions.ts
+++ b/src/redux/Actions.ts
@@ -23,6 +23,7 @@ import {
   isFirefoxAndroid,
   showNotification,
   sleep,
+  supportedStorageTypes,
 } from '../services/Libs';
 import {
   ADD_ACTIVITY_LOG,
@@ -290,10 +291,13 @@ export const validateSettings: ActionCreator<ThunkAction<
   // Disable unusable setting in Firefox Android
   if (isFirefoxAndroid(cache)) {
     disableSettingIfTrue(settings[SettingID.NUM_COOKIES_ICON]);
-    disableSettingIfTrue(settings[SettingID.CLEANUP_LOCALSTORAGE_OLD]);
-    disableSettingIfTrue(settings[SettingID.CLEANUP_LOCALSTORAGE]);
     disableSettingIfTrue(settings[SettingID.CONTEXTUAL_IDENTITIES]);
     disableSettingIfTrue(settings[SettingID.CONTEXT_MENUS]);
+  }
+
+  if (!supportedStorageTypes(cache).localStorage) {
+    disableSettingIfTrue(settings[SettingID.CLEANUP_LOCALSTORAGE_OLD]);
+    disableSettingIfTrue(settings[SettingID.CLEANUP_LOCALSTORAGE]);
   }
 
   // Minimum 1 second autoclean delay.

--- a/src/services/CleanupService.ts
+++ b/src/services/CleanupService.ts
@@ -18,8 +18,6 @@ import {
   getHostname,
   getSetting,
   isAWebpage,
-  isChrome,
-  isFirefoxNotAndroid,
   prepareCleanupDomains,
   prepareCookieDomain,
   returnMatchedExpressionObject,
@@ -28,6 +26,7 @@ import {
   siteDataToBrowser,
   SITEDATATYPES,
   sleep,
+  supportedStorageTypes,
   throwErrorNotification,
   trimDot,
   undefinedIsTrue,
@@ -566,13 +565,12 @@ export const otherBrowsingDataCleanup = async (
   state: State,
   isSafeToCleanObjects: CleanReasonObject[],
 ): Promise<ActivityLog['browsingDataCleanup']> => {
-  const chrome = isChrome(state.cache);
   const debug = getSetting(state, SettingID.DEBUG_MODE) as boolean;
   const browsingDataResult: ActivityLog['browsingDataCleanup'] = {};
-  const ffVersion = Number.parseInt(state.cache.browserVersion);
+  const supportedDataStorage = supportedStorageTypes(state.cache);
   if (
     getSetting(state, SettingID.CLEANUP_CACHE) &&
-    ((isFirefoxNotAndroid(state.cache) && ffVersion >= 78) || chrome)
+    supportedDataStorage.cache
   ) {
     browsingDataResult[SiteDataType.CACHE] = await cleanSiteData(
       state,
@@ -584,7 +582,7 @@ export const otherBrowsingDataCleanup = async (
   }
   if (
     getSetting(state, SettingID.CLEANUP_INDEXEDDB) &&
-    ((isFirefoxNotAndroid(state.cache) && ffVersion >= 77) || chrome)
+    supportedDataStorage.indexedDb
   ) {
     browsingDataResult[SiteDataType.INDEXEDDB] = await cleanSiteData(
       state,
@@ -596,7 +594,7 @@ export const otherBrowsingDataCleanup = async (
   }
   if (
     getSetting(state, SettingID.CLEANUP_LOCALSTORAGE) &&
-    ((isFirefoxNotAndroid(state.cache) && ffVersion >= 58) || chrome)
+    supportedDataStorage.localStorage
   ) {
     browsingDataResult[SiteDataType.LOCALSTORAGE] = await cleanSiteData(
       state,
@@ -608,7 +606,7 @@ export const otherBrowsingDataCleanup = async (
   }
   if (
     getSetting(state, SettingID.CLEANUP_PLUGINDATA) &&
-    ((isFirefoxNotAndroid(state.cache) && ffVersion >= 78) || chrome)
+    supportedDataStorage.pluginData
   ) {
     browsingDataResult[SiteDataType.PLUGINDATA] = await cleanSiteData(
       state,
@@ -620,7 +618,7 @@ export const otherBrowsingDataCleanup = async (
   }
   if (
     getSetting(state, SettingID.CLEANUP_SERVICEWORKERS) &&
-    ((isFirefoxNotAndroid(state.cache) && ffVersion >= 77) || chrome)
+    supportedDataStorage.serviceWorkers
   ) {
     browsingDataResult[SiteDataType.SERVICEWORKERS] = await cleanSiteData(
       state,

--- a/src/services/Libs.ts
+++ b/src/services/Libs.ts
@@ -557,6 +557,52 @@ export const isFirefox = (cache: CacheMap): boolean => {
   );
 };
 
+export const supportedStorageTypes = (
+  cache: CacheMap
+): StorageTypeSupportMap => {
+  if (isChrome(cache)) {
+    return {
+      cache: true,
+      indexedDb: true,
+      localStorage: true,
+      pluginData: true,
+      serviceWorkers: true,
+    };
+  }
+  // Can't verify support outside of FF and Chrome for now.
+  if (!isFirefox(cache)) {
+    return {
+      cache: false,
+      indexedDb: false,
+      localStorage: false,
+      pluginData: false,
+      serviceWorkers: false,
+    }
+  }
+
+  const ffVersion = Number.parseInt(cache.browserVersion);
+  // Firefox got support for different times in Android.
+  if (Object.prototype.hasOwnProperty.call(cache, 'platformOs') &&
+      cache.platformOs === 'android') {
+    return {
+      cache: (ffVersion >= 85),
+      indexedDb: (ffVersion >= 85),
+      localStorage: (ffVersion >= 85),
+      pluginData: (ffVersion >= 85),
+      serviceWorkers: (ffVersion >= 85),
+    };
+  }
+
+  // Desktop Firefox.
+  return {
+    cache: (ffVersion >= 78),
+    indexedDb: (ffVersion >= 77),
+    localStorage: (ffVersion >= 58),
+    pluginData: (ffVersion >= 78),
+    serviceWorkers: (ffVersion >= 77),
+  };
+};
+
 /**
  * Test if browser is Firefox Mobile/Android
  * @param cache Cache containing browserDetect and platformOs

--- a/src/typings/Global.d.ts
+++ b/src/typings/Global.d.ts
@@ -73,6 +73,14 @@ declare const enum SiteDataType {
   SERVICEWORKERS = 'ServiceWorkers',
 }
 
+type StorageTypeSupportMap = Readonly<{
+  cache: boolean;
+  indexedDb: boolean;
+  localStorage: boolean;
+  pluginData: boolean;
+  serviceWorkers: boolean;
+}>;
+
 type Setting = Readonly<{
   id?: string | number;
   name: string;

--- a/src/ui/common_components/ExpressionOptions.tsx
+++ b/src/ui/common_components/ExpressionOptions.tsx
@@ -19,8 +19,8 @@ import { updateExpressionUI } from '../../redux/Actions';
 import {
   isChrome,
   isFirefox,
-  isFirefoxNotAndroid,
   returnOptionalCookieAPIAttributes,
+  supportedStorageTypes,
 } from '../../services/Libs';
 import { ReduxAction } from '../../typings/ReduxConstants';
 interface DispatchProps {
@@ -276,32 +276,23 @@ class ExpressionOptions extends React.Component<ExpressionOptionsProps> {
     const ffVersion = Number.parseInt(state.cache.browserVersion);
 
     const dropList = coerceBoolean(expression.cleanAllCookies);
+    const supportedDataStorage = supportedStorageTypes(state.cache);
     return (
       <div>
         {!expression.expression.startsWith('file:') &&
-          ((isFirefoxNotAndroid(state.cache) &&
-            ffVersion >= 78) ||
-            isChrome(state.cache)) &&
+          supportedDataStorage.cache &&
           this.createSiteDataCheckbox(SiteDataType.CACHE)}
         {!expression.expression.startsWith('file:') &&
-          ((isFirefoxNotAndroid(state.cache) &&
-            ffVersion >= 77) ||
-            isChrome(state.cache)) &&
+          supportedDataStorage.indexedDb &&
           this.createSiteDataCheckbox(SiteDataType.INDEXEDDB)}
         {!expression.expression.startsWith('file:') &&
-          ((isFirefoxNotAndroid(state.cache) &&
-            ffVersion >= 58) ||
-            isChrome(state.cache)) &&
+          supportedDataStorage.localStorage &&
           this.createSiteDataCheckbox(SiteDataType.LOCALSTORAGE)}
         {!expression.expression.startsWith('file:') &&
-          ((isFirefoxNotAndroid(state.cache) &&
-            ffVersion >= 78) ||
-            isChrome(state.cache)) &&
+          supportedDataStorage.pluginData &&
           this.createSiteDataCheckbox(SiteDataType.PLUGINDATA)}
         {!expression.expression.startsWith('file:') &&
-          ((isFirefoxNotAndroid(state.cache) &&
-            ffVersion >= 77) ||
-            isChrome(state.cache)) &&
+          supportedDataStorage.serviceWorkers &&
           this.createSiteDataCheckbox(SiteDataType.SERVICEWORKERS)}
         <div className={'checkbox'}>
           <span

--- a/src/ui/settings/components/Settings.tsx
+++ b/src/ui/settings/components/Settings.tsx
@@ -20,6 +20,7 @@ import {
   isChrome,
   isFirefox,
   isFirefoxNotAndroid,
+  supportedStorageTypes,
 } from '../../../services/Libs';
 import { ReduxAction } from '../../../typings/ReduxConstants';
 import CheckboxSetting from '../../common_components/CheckboxSetting';
@@ -211,7 +212,7 @@ class Settings extends React.Component<SettingProps> {
     const { cache, onResetButtonClick, onUpdateSetting, settings, style } =
       this.props;
     const { error, success } = this.state;
-    const ffVersion = Number.parseInt(cache.browserVersion);
+    const supportedDataStorage = supportedStorageTypes(cache);
     return (
       <div style={style}>
         <h1>{browser.i18n.getMessage('settingsText')}</h1>
@@ -381,7 +382,7 @@ class Settings extends React.Component<SettingProps> {
           </div>
         </fieldset>
         <hr />
-        {(isFirefoxNotAndroid(cache) || isChrome(cache)) && (
+        {supportedDataStorage.localStorage && (
           <fieldset>
             <legend>
               {browser.i18n.getMessage('settingGroupOtherBrowsing')}
@@ -414,8 +415,7 @@ class Settings extends React.Component<SettingProps> {
                 }Warning`,
               )}
             </div>
-            {((isFirefoxNotAndroid(cache) && ffVersion >= 78) ||
-              isChrome(cache)) && (
+            {supportedDataStorage.cache && (
               <div className="form-group">
                 <CheckboxSetting
                   text={browser.i18n.getMessage('cacheCleanupText')}
@@ -428,8 +428,7 @@ class Settings extends React.Component<SettingProps> {
                 />
               </div>
             )}
-            {((isFirefoxNotAndroid(cache) && ffVersion >= 77) ||
-              isChrome(cache)) && (
+            {supportedDataStorage.indexedDb && (
               <div className="form-group">
                 <CheckboxSetting
                   text={browser.i18n.getMessage('indexedDBCleanupText')}
@@ -442,8 +441,7 @@ class Settings extends React.Component<SettingProps> {
                 />
               </div>
             )}
-            {((isFirefoxNotAndroid(cache) && ffVersion >= 58) ||
-              isChrome(cache)) && (
+            {supportedDataStorage.localStorage && (
               <div className="form-group">
                 <CheckboxSetting
                   text={browser.i18n.getMessage('localStorageCleanupText')}
@@ -456,8 +454,7 @@ class Settings extends React.Component<SettingProps> {
                 />
               </div>
             )}
-            {((isFirefoxNotAndroid(cache) && ffVersion >= 78) ||
-              isChrome(cache)) && (
+            {supportedDataStorage.pluginData && (
               <div className="form-group">
                 <CheckboxSetting
                   text={browser.i18n.getMessage('pluginDataCleanupText')}
@@ -470,8 +467,7 @@ class Settings extends React.Component<SettingProps> {
                 />
               </div>
             )}
-            {((isFirefoxNotAndroid(cache) && ffVersion >= 77) ||
-              isChrome(cache)) && (
+            {supportedDataStorage.serviceWorkers && (
               <div className="form-group">
                 <CheckboxSetting
                   text={browser.i18n.getMessage('serviceWorkersCleanupText')}


### PR DESCRIPTION
Firefox on Android now supports more than just cookies so the extension should allow users to manage those as well.

Replaces many uses of isFirefoxNotAndroid with simply isFirefox, but leaves in place some that are mainly about UI limitations. Completely removes the isFirefoxAndroid helper.

Without this many people may not realize that this extension is letting local storage persist through cookie cleaning, especially if they are familiar with the extension on desktop.